### PR TITLE
Task: Règle de validation pour les liens apprenti/formateur

### DIFF
--- a/orif/plafor/Controllers/Apprentice.php
+++ b/orif/plafor/Controllers/Apprentice.php
@@ -349,12 +349,25 @@ class Apprentice extends \App\Controllers\BaseController
             // so here we get every users that are trainer, then we create a array
             // with the matching constitution
 
-            // Gets data of trainers for the dropdown menu
+            // Gets data of trainers for the dropdown menu BUT ignore the trainers who are 
+            // already linked to the selected apprentice
             $trainersRaw = $this->user_model->getTrainers();
             $trainers = array();
+            $linked_apprentices = array();
 
             foreach ($trainersRaw as $trainer){
-                $trainers[$trainer['id']] = $trainer['username'];
+                $are_linked = false;
+                $linked_apprentices = $this->trainer_apprentice_model->getApprenticeIdsFromTrainer($trainer['id']);
+                if (!is_null($linked_apprentices)){
+                    foreach ($linked_apprentices as $id){
+                        if ($id == $id_apprentice){
+                            $are_linked = true;
+                        }
+                    }
+                }
+                if (!$are_linked){
+                    $trainers[$trainer['id']] = $trainer['username'];
+                }
             }
 
             // Data to send to the view


### PR DESCRIPTION
Actuellement, il est possible de lier le même apprenti et le même formateur plusieurs fois.

In the Apprentice Controllers, instead of just passing the list of all trainers, for each trainers
-> A existing method (getApprenticeIdsFromTrainer) is call and populate an array. 
-> If this array is NOT NULL, check if the selected apprentice ID is present.
 -> If NOT add the trainer to the array who gonna be send to the view.