### PR TITLE
fix: replace btn-default by btn-secondary

### DIFF
--- a/orif/plafor/Views/acquisition_status/save.php
+++ b/orif/plafor/Views/acquisition_status/save.php
@@ -48,7 +48,7 @@ helper('form');
         <!-- FORM BUTTONS -->
         <div class="row">
             <div class="col text-right">
-                <a class="btn btn-default" href="<?= base_url('plafor/apprentice/view_acquisition_status/'.$id); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+                <a class="btn btn-secondary" href="<?= base_url('plafor/apprentice/view_acquisition_status/'.$id); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
                 <?= form_submit('save', lang('common_lang.btn_save'), ['class' => 'btn btn-primary']); ?>
             </div>
         </div>

--- a/orif/plafor/Views/apprentice/delete.php
+++ b/orif/plafor/Views/apprentice/delete.php
@@ -21,7 +21,7 @@
                     <div class = "alert alert-info" ><?= lang('plafor_lang.apprentice_link_'.($apprentice['archive']==null?'disable_explanation':'enable_explanation'))?></div>
                 </div>
                 <div class="text-right">
-                    <a href="<?= base_url('plafor/apprentice/view_apprentice/'.$apprentice['id']); ?>" class="btn btn-default">
+                    <a href="<?= base_url('plafor/apprentice/view_apprentice/'.$apprentice['id']); ?>" class="btn btn-secondary">
                         <?= lang('common_lang.btn_cancel'); ?>
                     </a>
                     <a href="<?= base_url(uri_string().'/1'); ?>" class="btn btn-danger">

--- a/orif/plafor/Views/apprentice/link.php
+++ b/orif/plafor/Views/apprentice/link.php
@@ -71,7 +71,7 @@ $validation=\CodeIgniter\Config\Services::validation()
         <!-- FORM BUTTONS -->
         <div class="row">
             <div class="col text-right">
-                <a class="btn btn-default" href="<?= base_url("plafor/apprentice/view_apprentice/{$apprentice['id']}"); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+                <a class="btn btn-secondary" href="<?= base_url("plafor/apprentice/view_apprentice/{$apprentice['id']}"); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
                 <?= form_submit('save', lang('common_lang.btn_save'), ['class' => 'btn btn-primary']); ?>
             </div>
         </div>

--- a/orif/plafor/Views/comment/save.php
+++ b/orif/plafor/Views/comment/save.php
@@ -57,7 +57,7 @@ $validation=\CodeIgniter\Config\Services::validation()
     <!-- FORM BUTTONS -->
     <div class="row">
         <div class="col text-right">
-            <a class="btn btn-default" href="<?= base_url('plafor/apprentice/view_acquisition_status/'.$acquisition_status['id']); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+            <a class="btn btn-secondary" href="<?= base_url('plafor/apprentice/view_acquisition_status/'.$acquisition_status['id']); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
             <?= form_submit('save', lang('common_lang.btn_save'), ['class' => 'btn btn-primary']); ?>
         </div>
     </div>

--- a/orif/plafor/Views/competence_domain/delete.php
+++ b/orif/plafor/Views/competence_domain/delete.php
@@ -29,7 +29,7 @@ $session=\CodeIgniter\Config\Services::session();
                 <!-- BUTTONS -->
                 <div class="text-right">
                     <!-- CANCEL -->
-                    <a href="<?= base_url('plafor/courseplan/view_course_plan/'.$competence_domain['fk_course_plan']) ?>" class="btn btn-default">
+                    <a href="<?= base_url('plafor/courseplan/view_course_plan/'.$competence_domain['fk_course_plan']) ?>" class="btn btn-secondary">
                         <?= lang('common_lang.btn_cancel'); ?>
                     </a>
                     <!-- ENABLE / DISABLE -->

--- a/orif/plafor/Views/competence_domain/save.php
+++ b/orif/plafor/Views/competence_domain/save.php
@@ -75,7 +75,7 @@ $session=\CodeIgniter\Config\Services::session();
         <!-- FORM BUTTONS -->
         <div class="row">
             <div class="col text-right">
-                <a class="btn btn-default" href="<?= base_url('plafor/courseplan/view_course_plan/'.($fk_course_plan_id==null?'':$fk_course_plan_id)) ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+                <a class="btn btn-secondary" href="<?= base_url('plafor/courseplan/view_course_plan/'.($fk_course_plan_id==null?'':$fk_course_plan_id)) ?>"><?= lang('common_lang.btn_cancel'); ?></a>
                 <?= form_submit('save', lang('common_lang.btn_save'), ['class' => 'btn btn-primary']); ?>
             </div>
         </div>

--- a/orif/plafor/Views/course_plan/delete.php
+++ b/orif/plafor/Views/course_plan/delete.php
@@ -49,7 +49,7 @@ foreach ($courses as $course){
                     <div class = "alert alert-info" ><?= lang('plafor_lang.user_course_'.($course_plan['archive']==null?'disable_explanation':'enable_explanation'))?></div>
                 </div>
                 <div class="text-right">
-                    <a href="<?= /*base_url('apprentice/view_user_course/'.$apprentices[0]['id']);*/ $session->get('_ci_previous_url')?>" class="btn btn-default">
+                    <a href="<?= /*base_url('apprentice/view_user_course/'.$apprentices[0]['id']);*/ $session->get('_ci_previous_url')?>" class="btn btn-secondary">
                         <?= lang('common_lang.btn_cancel'); ?>
                     </a> 
                     <?php 

--- a/orif/plafor/Views/objective/delete.php
+++ b/orif/plafor/Views/objective/delete.php
@@ -25,7 +25,7 @@
                     <div class = "alert alert-info" ><?= lang('plafor_lang.objective_'.($objective['archive']==null?'disable_explanation':'enable_explanation'))?></div>
                 </div>
                 <div class="text-right">
-                    <a href="<?= base_url('plafor/courseplan/view_operational_competence/'.$objective['fk_operational_competence']); ?>" class="btn btn-default">
+                    <a href="<?= base_url('plafor/courseplan/view_operational_competence/'.$objective['fk_operational_competence']); ?>" class="btn btn-secondary">
                         <?= lang('common_lang.btn_cancel'); ?>
                     </a>
                     <?php 

--- a/orif/plafor/Views/objective/save.php
+++ b/orif/plafor/Views/objective/save.php
@@ -88,7 +88,7 @@ $validation=\CodeIgniter\Config\Services::validation();
         <!-- FORM BUTTONS -->
         <div class="row">
             <div class="col text-right">
-                <a class="btn btn-default" href="<?= base_url('plafor/courseplan/view_operational_competence/'.($operational_competence_id??'')); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+                <a class="btn btn-secondary" href="<?= base_url('plafor/courseplan/view_operational_competence/'.($operational_competence_id??'')); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
 				<?php if($objective && $objective['archive']) { ?>
 				<a href="<?=base_url('plafor/courseplan/delete_objective/'.$objective['id'].'/3')?>" class="btn btn-primary">
 					<?=lang('common_lang.btn_reactivate')?>

--- a/orif/plafor/Views/operational_competence/delete.php
+++ b/orif/plafor/Views/operational_competence/delete.php
@@ -25,7 +25,7 @@
                     <div class = "alert alert-info" ><?= lang('plafor_lang.operational_competence_'.($operational_competence['archive']==null?'disable_explanation':'enable_explanation'))?></div>
                 </div>
                 <div class="text-right">
-                    <a href="<?= base_url('plafor/courseplan/view_competence_domain/'.$operational_competence['fk_competence_domain']); ?>" class="btn btn-default">
+                    <a href="<?= base_url('plafor/courseplan/view_competence_domain/'.$operational_competence['fk_competence_domain']); ?>" class="btn btn-secondary">
                         <?= lang('common_lang.btn_cancel'); ?>
                     </a>
                     <?php 

--- a/orif/plafor/Views/operational_competence/save.php
+++ b/orif/plafor/Views/operational_competence/save.php
@@ -107,7 +107,7 @@ $validation=\CodeIgniter\Config\Services::validation();
         <!-- FORM BUTTONS -->
         <div class="row">
             <div class="col text-right">
-                <a class="btn btn-default" href="<?= base_url('plafor/courseplan/view_competence_domain/'.$competence_domain['id']) ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+                <a class="btn btn-secondary" href="<?= base_url('plafor/courseplan/view_competence_domain/'.$competence_domain['id']) ?>"><?= lang('common_lang.btn_cancel'); ?></a>
                 <?= form_submit('save', lang('common_lang.btn_save'), ['class' => 'btn btn-primary']); ?>
             </div>
         </div>

--- a/orif/plafor/Views/user_course/delete.php
+++ b/orif/plafor/Views/user_course/delete.php
@@ -16,7 +16,7 @@
                     <div class = "alert alert-info" ><?= lang('plafor_lang.user_course_delete_explanation')?></div>
                 </div>
                 <div class="text-right">
-                    <a href="<?= base_url('plafor/apprentice/view_user_course/'.$apprentice['id']); ?>" class="btn btn-default">
+                    <a href="<?= base_url('plafor/apprentice/view_user_course/'.$apprentice['id']); ?>" class="btn btn-secondary">
                         <?= lang('common_lang.btn_cancel'); ?>
                     </a>
                     <a href="<?= base_url(uri_string().'/1'); ?>" class="btn btn-danger">

--- a/orif/plafor/Views/user_course/save.php
+++ b/orif/plafor/Views/user_course/save.php
@@ -74,7 +74,7 @@ helper('form');
         <!-- FORM BUTTONS -->
         <div class="row">
             <div class="col text-right">
-                <a class="btn btn-default" href="<?= base_url('plafor/apprentice/view_apprentice/'.$apprentice['id']); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
+                <a class="btn btn-secondary" href="<?= base_url('plafor/apprentice/view_apprentice/'.$apprentice['id']); ?>"><?= lang('common_lang.btn_cancel'); ?></a>
                 <?= form_submit('save', lang('common_lang.btn_save'), ['class' => 'btn btn-primary']); ?>
             </div>
         </div>


### PR DESCRIPTION
In Bootstrap 4, `btn-default` is no longer an existing class.