### PR TITLE
hotfix: remove modules with a grade in the dropdown list form grade

### DIFF
--- a/orif/plafor/Helpers/grade_helper.php
+++ b/orif/plafor/Helpers/grade_helper.php
@@ -73,7 +73,9 @@ function getSubjectsOrModulesListByGradeId(int $gradeId): array
 
 function getModulesInArrayKey(int $userCourseId): array
 {
-    $list[lang('Grades.modules')] = getModules($userCourseId);
+    $list[lang('Grades.modules')] = getModules($userCourseId,
+        willBeFiltered: true);
+
     return $list;
 }
 


### PR DESCRIPTION
During #147, I forgot to put a parameter to true to remove modules with already a grade from the dropdown list.




**the relevant form**
![this form](https://github.com/user-attachments/assets/7a5ac003-1549-4efb-8b6a-2fa6049c2607)